### PR TITLE
Fix resetBoard comment

### DIFF
--- a/Codigo Miller.html
+++ b/Codigo Miller.html
@@ -981,7 +981,7 @@
             showSnackbar('Cartas aleatorizadas con éxito');
         }
 
-        // Reset the board
+        // Reset the entire game (cards, counts, and state)
         function resetBoard() {
             resetGame();
             showSnackbar('Tablero reiniciado con éxito');


### PR DESCRIPTION
## Summary
- clarify that `resetBoard` restarts the whole game rather than just the board

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a822d52e88321b4d921f4b3e20207