### PR TITLE
Add Jest test for shuffleArray

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codemiller",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/shuffleArray.js
+++ b/src/shuffleArray.js
@@ -1,0 +1,8 @@
+function shuffleArray(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+}
+module.exports = shuffleArray;

--- a/tests/shuffleArray.test.js
+++ b/tests/shuffleArray.test.js
@@ -1,0 +1,10 @@
+const shuffleArray = require('../src/shuffleArray');
+
+test('shuffleArray returns a permutation with same length and elements', () => {
+  const input = [1, 2, 3, 4, 5];
+  const result = shuffleArray([...input]);
+  expect(result).toHaveLength(input.length);
+  const sortedResult = [...result].sort();
+  const sortedInput = [...input].sort();
+  expect(sortedResult).toEqual(sortedInput);
+});


### PR DESCRIPTION
## Summary
- add `src/shuffleArray.js` with shuffle function
- configure Jest via `jest.config.js` and package.json
- add test verifying output permutation in `tests/shuffleArray.test.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a822dff808321ac1a13ac81a34ffe