### PR TITLE
Add automatic winner logic

### DIFF
--- a/Codigo Miller.html
+++ b/Codigo Miller.html
@@ -858,14 +858,22 @@
             if (card.type === 'red-team') {
                 gameState.redCardsLeft--;
                 updateTeamCounts();
-                checkForWin('red');
+                if (checkForWin('red')) {
+                    declareWinner('red');
+                }
             } else if (card.type === 'blue-team') {
                 gameState.blueCardsLeft--;
                 updateTeamCounts();
-                checkForWin('blue');
+                if (checkForWin('blue')) {
+                    declareWinner('blue');
+                }
             } else if (card.type === 'assassin') {
                 // Notify that assassin was found
                 showSnackbar('¡Carta asesina revelada!');
+
+                // Declare the opposing team as the winner
+                const winningTeam = gameState.currentTeam === 'red' ? 'blue' : 'red';
+                declareWinner(winningTeam);
             }
             
             // Update spymaster view to reflect the revealed card


### PR DESCRIPTION
## Summary
- trigger `declareWinner` in `revealCard` when a team finishes its cards
- end the game with the opposing team winning if the assassin is revealed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a822cfc908321b6377dcb9c871026