### PR TITLE
Set default card background image

### DIFF
--- a/Codigo Miller.html
+++ b/Codigo Miller.html
@@ -43,6 +43,9 @@
         }
         .card-front {
             background-color: #2d3748;
+            background-image: url('https://i.ibb.co/vCHhfW9M/card-background.jpg');
+            background-size: cover;
+            background-position: center;
             color: white;
         }
         .card-back {


### PR DESCRIPTION
## Summary
- set a default background image for card fronts

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687aa518ec688321a8e76a5a5d9311c0